### PR TITLE
BNF-like Grammar to define the language 

### DIFF
--- a/doc/Grammar.bnf
+++ b/doc/Grammar.bnf
@@ -95,7 +95,7 @@ import      = "@" FILE
 
 
 ; class are always public? no scope needed?
-class       = class_id SEP modifier_list NAME class_properties
+class       = CLASS_ID SEP modifier_list NAME class_properties
 
 
 class_properties
@@ -121,7 +121,8 @@ access_modifier
             | "#"
 
 
-access_block = access_modifier PAD ':' PAD class_prop_block_list
+class_access_block
+            = access_modifier PAD ":" PAD class_prop_block_list
 
 class_prop_block_list
             = class_prop_block SEP class_prop_block_list
@@ -176,7 +177,34 @@ constructor_with_access
 
 constructor = NAME PAD "(" argument_list PAD ")"
 
+interface   = INTERFACE_ID SEP modifier_list NAME interface_properties
+
+interface_properties
+            = PAD "{" PAD interface_prop_list "}"
+            | PAD ":" PAD interface_prop_list
+
+interface_prop_list
+            = interface_prop SEP interface_prop_list
+            | interface_prop
+
+interface_prop
+            = attribute_with_access
+            | method_with_access
+            | interface_access_block
+            | comment
+
+interface_access_block
+            = access_modifier PAD ":" PAD interface_prop_block_list
+
+interface_prop_block_list
+            = interface_prop_block SEP interface_prop_block_list
+            | interface_prop_block
+
+interface_prop_block
+            = attribute
+            | method
+            | comment
+
 ; TODO
-; interface
 ; reference
 ; package

--- a/doc/Grammar.bnf
+++ b/doc/Grammar.bnf
@@ -1,0 +1,151 @@
+; this is a comment
+; any line starting with ';' is a comment
+; rules are defined by a word and an '=' such as
+; "rule=..." where ... is the content of that rule
+; single quotes and double quotes signify the same thing, a string of case sensitive characters
+; a space serves as concatenation
+; ...? means the previous is present 0 or 1 times
+; ...* means the previous is present 0 or more times
+; ...+ means the previous is present 1 or more times
+; ...-... matches if it matches the previous and not the next, aka exclusion
+; [...] follows regular expression rules, [a-z] are all the characters from 'a' to 'z'
+; [^a-z] means all the characters except the ones from 'a' to 'z'
+; "" and '' matches the empty string
+
+
+
+
+
+class_id    = "class"
+interface_id= "interface"
+package_id  = "package"
+
+reserved    = class_id
+            | interface_id
+            | package_id
+
+; "- reserved" here signifies that a NAME cannot match the reserved rule
+NAME        = ([a-zA-Z_][a-zA-Z0-9_]*) - reserved
+
+SPACE       = " \t"
+
+EOF         = "\0"
+
+; EOL means anything ending a line
+EOL         = "\n"
+            | "\n\r"
+
+; this means we don’t care if left and right are separated
+; PAD is just a shorthand for PADDING
+PADDING     = (SPACE | EOL)*
+PAD         = PADDING
+
+; this means we need left and right to be separated
+; SEP is just a shorthand for SEPARATOR
+SEPARATOR   = (SPACE | EOL) PADDING
+SEP         = SEPARATOR
+
+Start       = PAD list PAD EOF
+
+list        = entry SEP list
+            | entry
+
+entry       = class
+            | interface
+            | reference
+            | package
+            | import
+            | comment
+
+
+comment     = "//" [^\n\r\0]*
+; TODO need to do /* comment */
+
+
+; FILE being any valid url (couldn't be bothered to do that one, pain in the a to specify properly)
+import      = "@" FILE
+
+
+
+; class are always public? no scope needed?
+class       = class_id SEP modifier_list NAME class_properties
+
+
+class_properties
+            = PAD "{" PAD class_prop_list "}"
+            | PAD ":" PAD class_prop_list
+
+class_prop_list
+            = class_prop SEP class_prop_list
+            | class_prop
+
+class_prop  = attribute_scoped
+            | method_scoped
+            | access_block
+            | comment
+
+; + for public
+; - for private
+; # for protected
+scope       = "+"
+            | "-"
+            | "#"
+
+
+access_block = scope PAD ':' PAD class_prop_block_list
+
+class_prop_block_list
+            = class_prop_block SEP class_prop_block_list
+            | class_prop_block
+
+class_prop_block
+            = attribute
+            | method
+            | comment
+
+; scope could be optional if we wanted to use the 'default' behaviour of java
+attribute_scoped
+            = scope attribute
+            | attribute
+
+attribute
+            = PAD modifier_list NAME PAD ":" PAD accessors PAD type
+
+modifier_list
+            = modifier SEP modifier_list
+            | modifier SEP
+            | ""
+
+modifier    = NAME
+
+accessors   = getter PAD setter
+            | getter
+            | setter PAD getter
+            | setter
+            | ""
+
+getter      = "-"
+
+setter      = "+"
+
+method_scoped
+            = scope method
+            | method
+
+method      = modifier_list NAME PAD "(" arguments PAD ")" PAD ":" PAD type
+
+arguments   = PAD modifier_list NAME PAD ":" PAD type SEP arguments
+            | PAD modifier_list NAME PAD ":" PAD type
+
+type        = NAME
+
+; TODO
+; interface
+; reference
+; package
+
+
+
+
+
+

--- a/doc/Grammar.bnf
+++ b/doc/Grammar.bnf
@@ -35,16 +35,18 @@ EOF         = "\0"
 EOL         = "\n"
             | "\n\r"
 
-; this means we don’t care if left and right are separated
+; we don’t care if left and right are separated
 ; PAD is just a shorthand for PADDING
 PADDING     = (SPACE | EOL)*
 PAD         = PADDING
 
-; this means we need left and right to be separated
+; we need left and right to be separated
 ; SEP is just a shorthand for SEPARATOR
 SEPARATOR   = (SPACE | EOL) PADDING
 SEP         = SEPARATOR
 
+
+; Starting rule
 Start       = PAD list PAD EOF
 
 list        = entry SEP list
@@ -57,9 +59,10 @@ entry       = class
             | import
             | comment
 
-
+; in truth, comments might be removed from the source file before lexing
 comment     = "//" [^\n\r\0]*
-; TODO need to do /* comment */
+; multiline comments
+            | "/*" ([^\0] - "*/")*
 
 
 ; FILE being any valid url (couldn't be bothered to do that one, pain in the a to specify properly)
@@ -79,20 +82,21 @@ class_prop_list
             = class_prop SEP class_prop_list
             | class_prop
 
-class_prop  = attribute_scoped
-            | method_scoped
+class_prop  = attribute_with_access
+            | method_with_access
             | access_block
             | comment
 
 ; + for public
 ; - for private
 ; # for protected
-scope       = "+"
+access_modifier
+            = "+"
             | "-"
             | "#"
 
 
-access_block = scope PAD ':' PAD class_prop_block_list
+access_block = access_modifier PAD ':' PAD class_prop_block_list
 
 class_prop_block_list
             = class_prop_block SEP class_prop_block_list
@@ -104,8 +108,8 @@ class_prop_block
             | comment
 
 ; scope could be optional if we wanted to use the 'default' behaviour of java
-attribute_scoped
-            = scope attribute
+attribute_with_access
+            = access_modifier attribute
             | attribute
 
 attribute
@@ -128,13 +132,14 @@ getter      = "-"
 
 setter      = "+"
 
-method_scoped
-            = scope method
+method_with_access
+            = access_modifier method
             | method
 
-method      = modifier_list NAME PAD "(" arguments PAD ")" PAD ":" PAD type
+method      = modifier_list NAME PAD "(" argument_list PAD ")" PAD ":" PAD type
 
-arguments   = PAD modifier_list NAME PAD ":" PAD type SEP arguments
+argument_list
+            = PAD modifier_list NAME PAD ":" PAD type SEP argument_list
             | PAD modifier_list NAME PAD ":" PAD type
 
 type        = NAME
@@ -143,9 +148,4 @@ type        = NAME
 ; interface
 ; reference
 ; package
-
-
-
-
-
-
+; class constructor

--- a/doc/Grammar.bnf
+++ b/doc/Grammar.bnf
@@ -43,10 +43,13 @@
 CLASS_ID    = "class"
 INTERFACE_ID= "interface"
 PACKAGE_ID  = "package"
+INHERITANCE_ID
+            = "->"
 
-RESERVED    = class_id
-            | interface_id
-            | package_id
+RESERVED    = CLASS_ID
+            | INTERFACE_ID
+            | PACKAGE_ID
+            | INHERITANCE_ID
 
 ; "- reserved" here signifies that a NAME cannot match the reserved rule
 NAME        = ([a-zA-Z_][a-zA-Z0-9_.]*) - RESERVED
@@ -78,7 +81,6 @@ list        = entry SEP list
 
 entry       = class
             | interface
-            | reference
             | package
             | import
             | comment
@@ -95,7 +97,7 @@ import      = "@" FILE
 
 
 ; class are always public? no scope needed?
-class       = CLASS_ID SEP modifier_list NAME class_properties
+class       = CLASS_ID SEP modifier_list NAME inheritance class_properties
 
 
 class_properties
@@ -176,7 +178,7 @@ constructor_with_access
 
 constructor = NAME PAD "(" argument_list PAD ")"
 
-interface   = INTERFACE_ID SEP modifier_list NAME interface_properties
+interface   = INTERFACE_ID SEP modifier_list NAME inheritance interface_properties
 
 interface_properties
             = PAD "{" PAD interface_prop_list "}"
@@ -206,5 +208,12 @@ interface_prop_block
 
 package     = PACKAGE_ID SEP NAME
 
+
+inheritance = PAD INHERITANCE_ID inheritance_list
+
+inheritance_list
+            = PAD NAME
+            | PAD NAME PAD ',' inheritance_list
+
 ; TODO
-; reference
+; reference -> inheritance done, other relationship in later PR

--- a/doc/Grammar.bnf
+++ b/doc/Grammar.bnf
@@ -35,10 +35,10 @@
 ;   [...] following POSIX extended regular expression rules in the manual grep(1)
 
 
-; a rule in CAPS is one that will be abstracted by the tokenizer
-; they are mostly here as a referece to make sure to follow the language specifications
-; in particular, PADDING and SEPARATOR will be removed from the token listing
-; and only serve to differenciate tokens for the tokenizer
+; A rule in CAPS is one that will be abstracted by the tokenizer.
+; They are mostly here as a referece to make sure we follow the language specifications.
+; In particular, PADDING and SEPARATOR will be removed from the token listing
+; and only serve to differenciate tokens for the tokenizer.
 
 CLASS_ID    = "class"
 INTERFACE_ID= "interface"
@@ -51,7 +51,7 @@ RESERVED    = CLASS_ID
             | PACKAGE_ID
             | INHERITANCE_ID
 
-; "- reserved" here signifies that a NAME cannot match the reserved rule
+; "- reserved" here signifies that a NAME cannot match the 'reserved' rule
 NAME        = ([a-zA-Z_][a-zA-Z0-9_.]*) - RESERVED
 
 SPACE       = [ \t]
@@ -62,12 +62,12 @@ EOF         = "\0"
 EOL         = "\n"
             | "\n\r"
 
-; we don’t care if left and right are separated
+; We do not care if left and right are separated
 ; PAD is just a shorthand for PADDING
 PADDING     = (SPACE | EOL)*
 PAD         = PADDING
 
-; we need left and right to be separated
+; We need left and right to be separated
 ; SEP is just a shorthand for SEPARATOR
 SEPARATOR   = (SPACE | EOL) PADDING
 SEP         = SEPARATOR
@@ -85,18 +85,25 @@ entry       = class
             | import
             | comment
 
-; in truth, comments might be removed from the source file before lexing
+; Comments might be removed from the source file before the tokenizer,
+; it will depend on the implementation we choose.
+; This would allow them to be more flexible compare to the rather limited
+; placement we have here.
 comment     = "//" [^\n\r\0]*
-; multiline comments
+; Multiline comments
             | "/*" ([^\0] - "*/")*
 
 
-; FILE being any valid url (couldn't be bothered to do that one, pain in the a to specify properly)
+; FILE being any valid url
+; (couldn't be bothered to do that one, pain in the a to specify properly)
 import      = "@" FILE
 
 
 
-; class are always public? no scope needed?
+; Classes are always public? in java at least, so no access modifiers needed.
+; This only holds for toplevel classes, but sub-classes have not been
+; implemented yet. This might change anyway when we try to implement more
+; languages.
 class       = CLASS_ID SEP modifier_list NAME inheritance class_properties
 
 
@@ -136,7 +143,8 @@ class_prop_block
             | constructor
             | comment
 
-; scope could be optional if we wanted to use the 'default' behaviour of java
+; The access modifier can be optional if we want to use the 'default'
+; behaviour of java.
 attribute_with_access
             = access_modifier attribute
             | attribute
@@ -206,8 +214,8 @@ interface_prop_block
             | method
             | comment
 
+; This might need some polishing later.
 package     = PACKAGE_ID SEP NAME
-
 
 inheritance = PAD INHERITANCE_ID inheritance_list
 

--- a/doc/Grammar.bnf
+++ b/doc/Grammar.bnf
@@ -1,33 +1,57 @@
-; this is a comment
-; any line starting with ';' is a comment
-; rules are defined by a word and an '=' such as
-; "rule=..." where ... is the content of that rule
-; single quotes and double quotes signify the same thing, a string of case sensitive characters
-; a space serves as concatenation
-; ...? means the previous is present 0 or 1 times
-; ...* means the previous is present 0 or more times
-; ...+ means the previous is present 1 or more times
-; ...-... matches if it matches the previous and not the next, aka exclusion
-; [...] follows regular expression rules, [a-z] are all the characters from 'a' to 'z'
-; [^a-z] means all the characters except the ones from 'a' to 'z'
-; "" and '' matches the empty string
+;   Rule:
+;   rule=...
+;
+;   Non-Terminal:
+;   "..." or '...'
+;
+;   Terminal:
+;   ...
+;
+;   Concat:
+;   ... ...
+;
+;   Choice:
+;   ...|...
+;
+;   Optional:
+;   ...?
+;
+;   0 or more:
+;   ...*
+;
+:   1 or more:
+;   ...+
+;
+;   Grouping:
+;   (...)
+;
+;   Exclusion:
+;   ...-...
+;
+;   Comment:
+;   ;...
+;
+;   Character Set:
+;   [...] following POSIX extended regular expression rules in the manual grep(1)
 
 
+; a rule in CAPS is one that will be abstracted by the tokenizer
+; they are mostly here as a referece to make sure to follow the language specifications
+; in particular, PADDING and SEPARATOR will be removed from the token listing
+; and only serve to differenciate tokens for the tokenizer
 
+CLASS_ID    = "class"
+INTERFACE_ID= "interface"
+PACKAGE_ID  = "package"
 
-
-class_id    = "class"
-interface_id= "interface"
-package_id  = "package"
-
-reserved    = class_id
+RESERVED    = class_id
             | interface_id
             | package_id
 
 ; "- reserved" here signifies that a NAME cannot match the reserved rule
-NAME        = ([a-zA-Z_][a-zA-Z0-9_]*) - reserved
+NAME        = ([a-zA-Z_][a-zA-Z0-9_]*) - RESERVED
 
-SPACE       = " \t"
+SPACE       = [ \t]
 
 EOF         = "\0"
 
@@ -84,6 +108,7 @@ class_prop_list
 
 class_prop  = attribute_with_access
             | method_with_access
+            | constructor_with_access
             | access_block
             | comment
 
@@ -105,6 +130,7 @@ class_prop_block_list
 class_prop_block
             = attribute
             | method
+            | constructor
             | comment
 
 ; scope could be optional if we wanted to use the 'default' behaviour of java
@@ -144,8 +170,13 @@ argument_list
 
 type        = NAME
 
+constructor_with_access
+            = access_modifier constructor
+            | constructor
+
+constructor = NAME PAD "(" argument_list PAD ")"
+
 ; TODO
 ; interface
 ; reference
 ; package
-; class constructor

--- a/doc/Grammar.bnf
+++ b/doc/Grammar.bnf
@@ -1,44 +1,45 @@
-;   Rule:
-;   rule=...
-;
-;   Non-Terminal:
-;   "..." or '...'
-;
-;   Terminal:
-;   ...
-;
-;   Concat:
-;   ... ...
-;
-;   Choice:
-;   ...|...
-;
-;   Optional:
-;   ...?
-;
-;   0 or more:
-;   ...*
-;
-:   1 or more:
-;   ...+
-;
-;   Grouping:
-;   (...)
-;
-;   Exclusion:
-;   ...-...
-;
-;   Comment:
-;   ;...
-;
-;   Character Set:
-;   [...] following POSIX extended regular expression rules in the manual grep(1)
+/*   Rule:
+     rule=...
 
+     Non-Terminal:
+     "..." or '...'
 
-; A rule in CAPS is one that will be abstracted by the tokenizer.
-; They are mostly here as a referece to make sure we follow the language specifications.
-; In particular, PADDING and SEPARATOR will be removed from the token listing
-; and only serve to differenciate tokens for the tokenizer.
+     Terminal:
+     ...
+
+     Concat:
+     ... ...
+
+     Choice:
+     ...|...
+
+     Optional:
+     ...?
+
+     0 or more:
+     ...*
+
+     1 or more:
+     ...+
+
+     Grouping:
+     (...)
+
+     Exclusion:
+     ...-...
+
+     Comment:
+     //...
+     and C style multilines
+
+     Character Set:
+     [...] following POSIX extended regular expression rules in the manual grep(1)
+
+     A rule in CAPS is one that will be abstracted by the tokenizer.
+     They are mostly here as a referece to make sure we follow the language specifications.
+     In particular, PADDING and SEPARATOR will be removed from the token listing
+     and only serve to differenciate tokens for the tokenizer.
+*/
 
 CLASS_ID    = "class"
 INTERFACE_ID= "interface"
@@ -51,29 +52,29 @@ RESERVED    = CLASS_ID
             | PACKAGE_ID
             | INHERITANCE_ID
 
-; "- reserved" here signifies that a NAME cannot match the 'reserved' rule
+// "- reserved" here signifies that a NAME cannot match the 'reserved' rule
 NAME        = ([a-zA-Z_][a-zA-Z0-9_.]*) - RESERVED
 
 SPACE       = [ \t]
 
 EOF         = "\0"
 
-; EOL means anything ending a line
+// EOL means anything ending a line
 EOL         = "\n"
             | "\n\r"
 
-; We do not care if left and right are separated
-; PAD is just a shorthand for PADDING
+// We do not care if left and right are separated
+// PAD is just a shorthand for PADDING
 PADDING     = (SPACE | EOL)*
 PAD         = PADDING
 
-; We need left and right to be separated
-; SEP is just a shorthand for SEPARATOR
+// We need left and right to be separated
+// SEP is just a shorthand for SEPARATOR
 SEPARATOR   = (SPACE | EOL) PADDING
 SEP         = SEPARATOR
 
 
-; Starting rule
+// Starting rule
 Start       = PAD list PAD EOF
 
 list        = entry SEP list
@@ -85,25 +86,27 @@ entry       = class
             | import
             | comment
 
-; Comments might be removed from the source file before the tokenizer,
-; it will depend on the implementation we choose.
-; This would allow them to be more flexible compare to the rather limited
-; placement we have here.
+/* Comments might be removed from the source file before the tokenizer,
+   it will depend on the implementation we choose.
+   This would allow them to be more flexible compare to the rather limited
+   placement we have here.
+*/
 comment     = "//" [^\n\r\0]*
-; Multiline comments
+// Multiline comments
             | "/*" ([^\0] - "*/")*
 
 
-; FILE being any valid url
-; (couldn't be bothered to do that one, pain in the a to specify properly)
+// FILE being any valid url
+// (couldn't be bothered to do that one, pain in the a to specify properly)
 import      = "@" FILE
 
 
 
-; Classes are always public? in java at least, so no access modifiers needed.
-; This only holds for toplevel classes, but sub-classes have not been
-; implemented yet. This might change anyway when we try to implement more
-; languages.
+/* Classes are always public? in java at least, so no access modifiers needed.
+   This only holds for toplevel classes, but sub-classes have not been
+   implemented yet. This might change anyway when we try to implement more
+   languages.
+*/
 class       = CLASS_ID SEP modifier_list NAME inheritance class_properties
 
 
@@ -121,9 +124,10 @@ class_prop  = attribute_with_access
             | access_block
             | comment
 
-; + for public
-; - for private
-; # for protected
+/* + for public
+   - for private
+   # for protected
+*/
 access_modifier
             = "+"
             | "-"
@@ -143,8 +147,8 @@ class_prop_block
             | constructor
             | comment
 
-; The access modifier can be optional if we want to use the 'default'
-; behaviour of java.
+// The access modifier can be optional if we want to use the 'default'
+// behaviour of java.
 attribute_with_access
             = access_modifier attribute
             | attribute
@@ -214,7 +218,7 @@ interface_prop_block
             | method
             | comment
 
-; This might need some polishing later.
+// This might need some polishing later.
 package     = PACKAGE_ID SEP NAME
 
 inheritance = PAD INHERITANCE_ID inheritance_list
@@ -223,5 +227,5 @@ inheritance_list
             = PAD NAME
             | PAD NAME PAD ',' inheritance_list
 
-; TODO
-; reference -> inheritance done, other relationship in later PR
+// TODO
+// reference -> inheritance done, other relationship in later PR

--- a/doc/Grammar.bnf
+++ b/doc/Grammar.bnf
@@ -49,7 +49,7 @@ RESERVED    = class_id
             | package_id
 
 ; "- reserved" here signifies that a NAME cannot match the reserved rule
-NAME        = ([a-zA-Z_][a-zA-Z0-9_]*) - RESERVED
+NAME        = ([a-zA-Z_][a-zA-Z0-9_.]*) - RESERVED
 
 SPACE       = [ \t]
 
@@ -139,8 +139,7 @@ attribute_with_access
             = access_modifier attribute
             | attribute
 
-attribute
-            = PAD modifier_list NAME PAD ":" PAD accessors PAD type
+attribute   = PAD modifier_list NAME PAD ":" PAD accessors PAD type
 
 modifier_list
             = modifier SEP modifier_list
@@ -205,6 +204,7 @@ interface_prop_block
             | method
             | comment
 
+package     = PACKAGE_ID SEP NAME
+
 ; TODO
 ; reference
-; package


### PR DESCRIPTION
What we do have:

## Class
- prototype:
  - modifiers
  - name
- inheritances:
  - name
- constructors:
  - access modifiers
    - private (`-`)
    - public (`+`)
    - protected (`#`)
  - name 
       -> might not be needed? not in Java at least, but maybe other languages allow for a different name?
  - argument:
    - name
    - modifiers
    - type
- methods:
  - access modifiers
    - private (`-`)
    - public (`+`)
    - protected (`#`)
  - modifiers
  - name
  - return type
  - argument:
    - name
    - modifiers
    - type
- attributes:
  - modifiers
  - type
  - name
  - access modifiers
    - private (`-`)
    - public (`+`)
    - protected (`#`)
 - access modifiers blocks
    - private (`-:`)
    - public (`+:`)
    - protected (`#:`)

## Interface
- prototype:
  - modifiers
  - name
- methods:
  - access modifiers
    - private (`-`)
    - public (`+`)
    - protected (`#`)
  - modifiers
  - name
  - return type
  - argument:
    - name
    - modifiers
    - type
- attributes:
  - modifiers
  - type
  - name
  - access modifiers
    - private (`-`)
    - public (`+`)
    - protected (`#`)
 - access modifiers blocks
    - private (`-:`)
    - public (`+:`)
    - protected (`#:`)


## Import

`@FILE` where FILE has to be an url, though that is not defined in the BNF itself...
might need to be done

## Comments

Starts with `//` and continue until the end of the line



Not done yet:

- [x] Class constructors 
- [x] Interfaces
- [x] Reference (OOP relations)
- [x] Packages
- [x] multi-line comments

Might be missing a few more things